### PR TITLE
option to disable simultaneous sound playback

### DIFF
--- a/soundboard.toml
+++ b/soundboard.toml
@@ -1,7 +1,8 @@
-# input_device = "Mikrofonarray (Realtek High Definition Audio(SST))" # optional else default device
-# output_device = "Speaker/HP (Realtek High Definition Audio(SST))" # optional else default device
-# loopback_device = "CABLE Input (VB-Audio Virtual Cable)" # required: change to your virtual loopback output
+# input_device      = "Mikrofonarray (Realtek High Definition Audio(SST))" # optional else default device
+# output_device     = "Speaker/HP (Realtek High Definition Audio(SST))" # optional else default device
+# loopback_device   = "CABLE Input (VB-Audio Virtual Cable)" # required: change to your virtual loopback output
 
-http_server = true # api and webui; 3030 is the default port
-no_gui = false # no native gui
-stop_hotkey = "CTRL-ALT-E" # stop all sound
+http_server = true                      # api and webui; 3030 is the default port
+no_gui      = false                     # no native gui
+stop_hotkey = "CTRL-ALT-E"              # stop all sound
+disable_simultaneous_playback = true    # stop currently playing sounds when playing a new sound

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,8 +67,16 @@ fn load_and_merge_config() -> Result<MainConfig> {
     merge_flag_with_args_and_env(&mut config.telegram, &arguments, "telegram");
     merge_flag_with_args_and_env(&mut config.no_gui, &arguments, "no-gui");
     merge_flag_with_args_and_env(&mut config.no_duplex_device, &arguments, "no-duplex-device");
-	merge_flag_with_args_and_env(&mut config.print_possible_devices, &arguments,"print-possible-devices");
-    merge_flag_with_args_and_env(&mut config.disable_simultaneous_playback, &arguments, "disable-simultaneous-playback");
+    merge_flag_with_args_and_env(
+        &mut config.print_possible_devices,
+        &arguments,
+        "print-possible-devices",
+    );
+    merge_flag_with_args_and_env(
+        &mut config.disable_simultaneous_playback,
+        &arguments,
+        "disable-simultaneous-playback",
+    );
 
     Ok(config)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,7 @@ pub struct MainConfig {
     pub auto_loop_device: Option<bool>,
     pub no_duplex_device: Option<bool>,
     pub print_possible_devices: Option<bool>,
+    pub disable_simultaneous_playback: Option<bool>,
 
     #[serde(skip_serializing, skip_deserializing)]
     pub soundboards: Vec<SoundboardConfig>,
@@ -66,11 +67,9 @@ fn load_and_merge_config() -> Result<MainConfig> {
     merge_flag_with_args_and_env(&mut config.telegram, &arguments, "telegram");
     merge_flag_with_args_and_env(&mut config.no_gui, &arguments, "no-gui");
     merge_flag_with_args_and_env(&mut config.no_duplex_device, &arguments, "no-duplex-device");
-    merge_flag_with_args_and_env(
-        &mut config.print_possible_devices,
-        &arguments,
-        "print-possible-devices",
-    );
+	merge_flag_with_args_and_env(&mut config.print_possible_devices, &arguments,"print-possible-devices");
+    merge_flag_with_args_and_env(&mut config.disable_simultaneous_playback, &arguments, "disable-simultaneous-playback");
+
     Ok(config)
 }
 

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -358,7 +358,7 @@ fn run_sound_message_loop(
                         }
                         result.unwrap()
                     };
-                    
+
                     if config::MainConfig::read()
                         .disable_simultaneous_playback
                         .unwrap_or_default()

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -358,6 +358,15 @@ fn run_sound_message_loop(
                         }
                         result.unwrap()
                     };
+                    
+                    if config::MainConfig::read()
+                        .disable_simultaneous_playback
+                        .unwrap_or_default()
+                    {
+                        gui_sender
+                            .send(Message::StopAll)
+                            .expect("error stopping all playing sounds");
+                    }
 
                     if let Some(path) = maybe_path {
                         gui_sender


### PR DESCRIPTION
Added option to disable simultaneous playback of any sound. If this option is enabled all currently playing sounds will be stopped before the next sound is played.